### PR TITLE
Fixed null reference exception when refreshing sign-in state

### DIFF
--- a/src/SignIn/Api/CommitHooks.cs
+++ b/src/SignIn/Api/CommitHooks.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Web;
-using System.Collections.Generic;
-using System.Collections.Specialized;
-using Starcounter;
-using Starcounter.Internal;
+﻿using Starcounter;
 using Simplified.Ring5;
 
 namespace SignIn
@@ -13,9 +8,7 @@ namespace SignIn
         public void Register()
         {
             Hook<SystemUserSession>.CommitInsert += (s, a) => { this.RefreshSignInState(); };
-
             Hook<SystemUserSession>.CommitDelete += (s, a) => { this.RefreshSignInState(); };
-
             Hook<SystemUserSession>.CommitUpdate += (s, a) => { this.RefreshSignInState(); };
         }
 
@@ -24,7 +17,7 @@ namespace SignIn
             if (Session.Current != null)
             {
                 var master = Session.Current.Data as MasterPage;
-                master.RefreshSignInState();
+                master?.RefreshSignInState();
             }
         }
     }


### PR DESCRIPTION
Hotfix for https://github.com/StarcounterApps/SignIn/pull/86.

I got following error:
```
System.NullReferenceException: Ссылка на объект не указывает на экземпляр объекта.
   в SignIn.CommitHooks.RefreshSignInState() в C:\Users\untone\Documents\Projects\Starcounter\Git\StarcounterApps\SignIn\src\SignIn\Api\CommitHooks.cs:строка 27
   в SignIn.CommitHooks.<Register>b__0_0(Object s, SystemUserSession a) в C:\Users\untone\Documents\Projects\Starcounter\Git\StarcounterApps\SignIn\src\SignIn\Api\CommitHooks.cs:строка 15
   в Starcounter.RuntimeInstalledHookDelegate`1.Invoke(Object triggeringObject) в C:\TeamCity\BuildAgent\work\sc-4704\Level1\src\Starcounter\Hooks\RuntimeInstalledHookDelegate.cs:строка 37
   в Starcounter.InvokableHook.InvokeAllWithKey(HookKey key, Object instance) в C:\TeamCity\BuildAgent\work\sc-4704\Level1\src\Starcounter\Hooks\InvokableHook.cs:строка 72
   в Starcounter.Internal.TransactionManager.InvokeHooks() в C:\TeamCity\BuildAgent\work\sc-4704\Level1\src\Starcounter\TransactionManager.cs:строка 806
   в Starcounter.Internal.TransactionManager.Commit(UInt64 handle, Int32 free) в C:\TeamCity\BuildAgent\work\sc-4704\Level1\src\Starcounter\TransactionManager.cs:строка 704
   в Starcounter.Db.TransactAsync(Action action, UInt32 flags, TransactOptions opts) в C:\TeamCity\BuildAgent\work\sc-4704\Level1\src\Starcounter\Db.cs:строка 283
   в Starcounter.Db.Transact(Action action, UInt32 flags, TransactOptions opts) в C:\TeamCity\BuildAgent\work\sc-4704\Level1\src\Starcounter\Db.cs:строка 340
   в Simplified.Ring3.SystemUser.SignInSystemUser(String AuthToken) в C:\TeamCity\BuildAgent\work\sc-4704\Simplified\Ring3\User\SystemUser.Static.cs:строка 310
   в SignIn.MainHandlers.<Register>b__2_0(Request req) в C:\Users\untone\Documents\Projects\Starcounter\Git\StarcounterApps\SignIn\src\SignIn\Api\MainHandlers.cs:строка 48
   в Starcounter.Handle.RunRequestFilters(Request req) в C:\TeamCity\BuildAgent\work\sc-4704\Level1\src\Starcounter.Internal\Handle.cs:строка 495
   в Starcounter.Internal.AppsBootstrapper.ProcessExternalRequest(Request req) в C:\TeamCity\BuildAgent\work\sc-4704\Level1\src\Starcounter.Apps.JsonPatch\AppsBootstrapper.cs:строка 755
HResult=-2147467261

More information about this error may be available in the server error log.
```